### PR TITLE
New helper methods

### DIFF
--- a/src/multiassayexperiment/MultiAssayExperiment.py
+++ b/src/multiassayexperiment/MultiAssayExperiment.py
@@ -1296,3 +1296,12 @@ class MultiAssayExperiment:
             sample_map=sample_map,
             metadata=input.uns,
         )
+
+@ut.extract_row_names.register(MultiAssayExperiment)
+def _rownames_bframe(x: MultiAssayExperiment):
+    return x.get_row_names()
+
+
+@ut.extract_column_names.register(MultiAssayExperiment)
+def _colnames_bframe(x: MultiAssayExperiment):
+    return x.get_column_names()

--- a/src/multiassayexperiment/MultiAssayExperiment.py
+++ b/src/multiassayexperiment/MultiAssayExperiment.py
@@ -1063,7 +1063,7 @@ class MultiAssayExperiment:
     def columnnames(self) -> Dict[str, Optional[ut.Names]]:
         """Alias for :py:attr:`~get_column_names`, provided for back-compatibility."""
         return self.get_column_names()
-    
+
     @property
     def colnames(self) -> Dict[str, Optional[ut.Names]]:
         """Alias for :py:attr:`~get_column_names`, provided for back-compatibility."""
@@ -1297,11 +1297,12 @@ class MultiAssayExperiment:
             metadata=input.uns,
         )
 
+
 @ut.extract_row_names.register(MultiAssayExperiment)
-def _rownames_bframe(x: MultiAssayExperiment):
+def _rownames_mae(x: MultiAssayExperiment):
     return x.get_row_names()
 
 
 @ut.extract_column_names.register(MultiAssayExperiment)
-def _colnames_bframe(x: MultiAssayExperiment):
+def _colnames_mae(x: MultiAssayExperiment):
     return x.get_column_names()

--- a/src/multiassayexperiment/MultiAssayExperiment.py
+++ b/src/multiassayexperiment/MultiAssayExperiment.py
@@ -1035,7 +1035,7 @@ class MultiAssayExperiment:
     def get_row_names(self) -> Dict[str, Optional[ut.Names]]:
         """
         Returns:
-            Dictionary of row names for each experiment.
+            Dictionary, with experiment names as keys, and row names as values.
         """
         _all_row_names = {}
         for expname, expt in self._experiments.items():
@@ -1051,7 +1051,7 @@ class MultiAssayExperiment:
     def get_column_names(self) -> Dict[str, Optional[ut.Names]]:
         """
         Returns:
-            Dictionary of row names for each experiment.
+            Dictionary, with experiment names as keys, and the column names as values.
         """
         _all_row_names = {}
         for expname, expt in self._experiments.items():

--- a/src/multiassayexperiment/MultiAssayExperiment.py
+++ b/src/multiassayexperiment/MultiAssayExperiment.py
@@ -1001,6 +1001,79 @@ class MultiAssayExperiment:
 
         return replicates
 
+    def find_common_row_names(self) -> List[str]:
+        """Finds common row names across all experiments."""
+
+        _common = None
+        for _, expt in self._experiments.items():
+            if _common is None:
+                _common = set(expt.row_names)
+            else:
+                _common = set(expt.row_names).intersection(_common)
+
+        return _common
+
+    def intersect_rows(self) -> "MultiAssayExperiment":
+        """Finds common row names across all experiments and filters the MAE to these rows.
+
+        Returns:
+            A new sliced `MultiAssayExperiment` object with the filtered rows.
+        """
+        _common_row_names = self.find_common_row_names()
+        sresult = self._generic_slice(rows=_common_row_names)
+        return MultiAssayExperiment(
+            sresult.experiments,
+            sresult.column_data,
+            sresult.sample_map,
+            self.metadata,
+        )
+
+    ####################################
+    ######>> row or column names <<#####
+    ####################################
+
+    def get_row_names(self) -> Dict[str, Optional[ut.Names]]:
+        """
+        Returns:
+            Dictionary of row names for each experiment.
+        """
+        _all_row_names = {}
+        for expname, expt in self._experiments.items():
+            _all_row_names[expname] = expt.row_names
+
+        return _all_row_names
+
+    @property
+    def rownames(self) -> Dict[str, Optional[ut.Names]]:
+        """Alias for :py:attr:`~get_row_names`, provided for back-compatibility."""
+        return self.get_row_names()
+
+    def get_column_names(self) -> Dict[str, Optional[ut.Names]]:
+        """
+        Returns:
+            Dictionary of row names for each experiment.
+        """
+        _all_row_names = {}
+        for expname, expt in self._experiments.items():
+            _all_row_names[expname] = expt.column_names
+
+        return _all_row_names
+
+    @property
+    def columnnames(self) -> Dict[str, Optional[ut.Names]]:
+        """Alias for :py:attr:`~get_column_names`, provided for back-compatibility."""
+        return self.get_column_names()
+    
+    @property
+    def colnames(self) -> Dict[str, Optional[ut.Names]]:
+        """Alias for :py:attr:`~get_column_names`, provided for back-compatibility."""
+        return self.get_column_names()
+
+    @property
+    def column_names(self) -> Dict[str, Optional[ut.Names]]:
+        """Alias for :py:attr:`~get_column_names`, provided for back-compatibility."""
+        return self.get_column_names()
+
     #################################
     ######>> add experiment <<#######
     #################################

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -231,3 +231,57 @@ def test_with_sample_data():
     assert expt_with_sample_data.column_data is not None
     print(expt_with_sample_data.column_data)
     assert expt_with_sample_data.column_data.get_column("samples") is not None
+
+def test_MAE_intersect_methods():
+    tsce = SingleCellExperiment(
+        assays={"counts": counts}, row_data=df_gr, column_data=column_data_sce
+    )
+
+    tse2 = SummarizedExperiment(
+        assays={"counts": counts.copy()},
+        row_data=df_gr.copy(),
+        column_data=column_data_se.copy(),
+    )
+
+    mae = MultiAssayExperiment(
+        experiments={"sce": tsce, "se": tse2},
+        column_data=sample_data,
+        sample_map=sample_map,
+        metadata={"could be": "anything"},
+    )
+    
+
+    row_mae = mae.intersect_rows()
+    assert row_mae is not None
+    assert isinstance(row_mae, MultiAssayExperiment)
+    assert row_mae.experiment_names == mae.experiment_names
+
+
+
+def test_MAE_names():
+    tsce = SingleCellExperiment(
+        assays={"counts": counts}, row_data=df_gr, column_data=column_data_sce
+    )
+
+    tse2 = SummarizedExperiment(
+        assays={"counts": counts.copy()},
+        row_data=df_gr.copy(),
+        column_data=column_data_se.copy(),
+    )
+
+    mae = MultiAssayExperiment(
+        experiments={"sce": tsce, "se": tse2},
+        column_data=sample_data,
+        sample_map=sample_map,
+        metadata={"could be": "anything"},
+    )
+
+
+    rownames = mae.rownames
+    colnames = mae.column_names
+
+    assert rownames is not None
+    assert len(rownames) == len(mae.experiments)
+    
+    assert colnames is not None
+    assert len(colnames) == len(mae.experiments)

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -232,6 +232,7 @@ def test_with_sample_data():
     print(expt_with_sample_data.column_data)
     assert expt_with_sample_data.column_data.get_column("samples") is not None
 
+
 def test_MAE_intersect_methods():
     tsce = SingleCellExperiment(
         assays={"counts": counts}, row_data=df_gr, column_data=column_data_sce
@@ -249,13 +250,11 @@ def test_MAE_intersect_methods():
         sample_map=sample_map,
         metadata={"could be": "anything"},
     )
-    
 
     row_mae = mae.intersect_rows()
     assert row_mae is not None
     assert isinstance(row_mae, MultiAssayExperiment)
     assert row_mae.experiment_names == mae.experiment_names
-
 
 
 def test_MAE_names():
@@ -276,12 +275,11 @@ def test_MAE_names():
         metadata={"could be": "anything"},
     )
 
-
     rownames = mae.rownames
     colnames = mae.column_names
 
     assert rownames is not None
     assert len(rownames) == len(mae.experiments)
-    
+
     assert colnames is not None
     assert len(colnames) == len(mae.experiments)


### PR DESCRIPTION
Methods to
- Subset rows across experiments to a common set of row names.
- Accessor (read-only) to get row or column names across all experiments.

